### PR TITLE
Improve parsing of empty nulls and lists of objects

### DIFF
--- a/samples/hie.lua
+++ b/samples/hie.lua
@@ -1,0 +1,120 @@
+return {
+  ["cradle"] = {
+    ["multi"] = {
+      [1] = {
+        ["path"] = "./bazel-bin",
+        ["config"] = {
+          ["cradle"] = {}
+        }
+      },
+      [2] = {
+        ["path"] = "./bazel-out",
+        ["config"] = {
+          ["cradle"] = {}
+        }
+      },
+      [3] = {
+        ["path"] = "./bazel-testlogs",
+        ["config"] = {
+          ["cradle"] = {}
+        }
+      },
+      [4] = {
+        ["path"] = "./bazel-yesod-bridge",
+        ["config"] = {
+          ["cradle"] = {}
+        }
+      },
+      [5] = {
+        ["path"] = "./bazel-hls-bin",
+        ["config"] = {
+          ["cradle"] = {}
+        }
+      },
+      [6] = {
+        ["path"] = "./bazel-hls-out",
+        ["config"] = {
+          ["cradle"] = {}
+        }
+      },
+      [7] = {
+        ["path"] = "./bazel-hls-testlogs",
+        ["config"] = {
+          ["cradle"] = {}
+        }
+      },
+      [8] = {
+        ["path"] = "./bazel-hls-yesod-bridge",
+        ["config"] = {
+          ["cradle"] = {}
+        }
+      },
+      [9] = {
+        ["path"] = "./bridge-site",
+        ["config"] = {
+          ["cradle"] = {
+            ["bios"] = {
+              ["program"] = "./bridge-site/.hie-bios"
+            }
+          }
+        }
+      },
+      [10] = {
+        ["path"] = "./cassandra-util",
+        ["config"] = {
+          ["cradle"] = {
+            ["bios"] = {
+              ["program"] = "./cassandra-util/.hie-bios"
+            }
+          }
+        }
+      },
+      [11] = {
+        ["path"] = "./conduit-util",
+        ["config"] = {
+          ["cradle"] = {
+            ["bios"] = {
+              ["program"] = "./conduit-util/.hie-bios"
+            }
+          }
+        }
+      },
+      [12] = {
+        ["path"] = "./hsx-util",
+        ["config"] = {
+          ["cradle"] = {
+            ["bios"] = {
+              ["program"] = "./hsx-util/.hie-bios"
+            }
+          }
+        }
+      },
+      [13] = {
+        ["path"] = "./page",
+        ["config"] = {
+          ["cradle"] = {
+            ["bios"] = {
+              ["program"] = "./page/.hie-bios"
+            }
+          }
+        }
+      },
+      [14] = {
+        ["path"] = "./wai-practice",
+        ["config"] = {
+          ["cradle"] = {
+            ["bios"] = {
+              ["program"] = "./wai-practice/.hie-bios"
+            }
+          }
+        }
+      },
+      [15] = {
+        ["path"] = "./",
+        ["config"] = {
+          ["cradle"] = {}
+        }
+      }
+    }
+  }
+}

--- a/samples/hie.yaml
+++ b/samples/hie.yaml
@@ -1,0 +1,68 @@
+cradle:
+  multi:
+    - path: "./bazel-bin"
+      config:
+        cradle:
+          none:
+    - path: "./bazel-out"
+      config:
+        cradle:
+          none:
+    - path: "./bazel-testlogs"
+      config:
+        cradle:
+          none:
+    - path: "./bazel-yesod-bridge"
+      config:
+        cradle:
+          none:
+    - path: "./bazel-hls-bin"
+      config:
+        cradle:
+          none:
+    - path: "./bazel-hls-out"
+      config:
+        cradle:
+          none:
+    - path: "./bazel-hls-testlogs"
+      config:
+        cradle:
+          none:
+    - path: "./bazel-hls-yesod-bridge"
+      config:
+        cradle:
+          none:
+    - path: "./bridge-site"
+      config:
+        cradle:
+          bios:
+            program: "./bridge-site/.hie-bios"
+    - path: "./cassandra-util"
+      config:
+        cradle:
+          bios:
+            program: "./cassandra-util/.hie-bios"
+    - path: "./conduit-util"
+      config:
+        cradle:
+          bios:
+            program: "./conduit-util/.hie-bios"
+    - path: "./hsx-util"
+      config:
+        cradle:
+          bios:
+            program: "./hsx-util/.hie-bios"
+    - path: "./page"
+      config:
+        cradle:
+          bios:
+            program: "./page/.hie-bios"
+    - path: "./wai-practice"
+      config:
+        cradle:
+          bios:
+            program: "./wai-practice/.hie-bios"
+    - path: "./"
+      config:
+        cradle:
+          none:

--- a/samples/null.lua
+++ b/samples/null.lua
@@ -1,4 +1,17 @@
 return {
+  ["empties"] = {
+    [1] = {},
+    [2] = {
+      ["nonEmptyInitial"] = 7,
+      ["nonEmptyFinal"] = 8,
+    },
+    [3] = {
+      ["nonEmptyFinal"] = 9,
+    },
+    [4] = {
+      ["nonEmptyInitial"] = 10,
+    }
+  },
   ["end"] = "test passed?",
   ["notnull"] = true,
   ["test"] = "A test for null values"

--- a/samples/null.yaml
+++ b/samples/null.yaml
@@ -3,6 +3,16 @@
   thisis: null
   thistoo: NULL
   notnull: yes
+  empties:
+  - emptySolo:
+  - nonEmptyInitial: 7
+    emptyCentral:
+    nonEmptyFinal: 8
+  - emptyInitial:
+    nonEmptyFinal: 9
+  - nonEmptyInitial: 10
+    emptyFinal:
+  - emptyTerminal:
   tildeis: ~
   capitalized: Null
   end: test passed?

--- a/yaml.lua
+++ b/yaml.lua
@@ -471,7 +471,7 @@ Parser.parseHash = function (self, hash)
 
   if self:isInline() then
     local id = self:advanceValue()
-    self:expect(":", "expected semi-colon after id")
+    self:expect(":", "expected colon after id")
     self:ignoreSpace()
     if self:accept("indent") then
       indents = indents + 1
@@ -487,7 +487,7 @@ Parser.parseHash = function (self, hash)
 
   while self:peekType("id") do
     local id = self:advanceValue()
-    self:expect(":","expected semi-colon after id")
+    self:expect(":","expected colon after id")
     self:ignoreSpace()
     hash[id] = self:parse()
     self:ignoreSpace();


### PR DESCRIPTION
Use lookahead to improve parsing of empty keys  that should be parsed as null and lists consisting of items.

All current tests pass, and the null test has been expanded to include cases that would fail without this code.